### PR TITLE
Support record headers

### DIFF
--- a/lib/kayrock/record_batch.ex
+++ b/lib/kayrock/record_batch.ex
@@ -401,9 +401,10 @@ defmodule Kayrock.RecordBatch do
   end
 
   defp serialize_record_headers(headers) do
-    headers_len = encode_varint(length(headers))
+    valid_headers = Enum.filter(headers, fn h -> !is_nil(h.key) end)
+    headers_len = encode_varint(length(valid_headers))
 
-    Enum.reduce(headers, headers_len, fn h, acc ->
+    Enum.reduce(valid_headers, headers_len, fn h, acc ->
       acc <>
         encode_varint(byte_size(h.key)) <>
         <<h.key::binary>> <>

--- a/lib/kayrock/record_batch.ex
+++ b/lib/kayrock/record_batch.ex
@@ -315,7 +315,7 @@ defmodule Kayrock.RecordBatch do
           {nil, rest}
 
         len ->
-          <<val::size(value_len)-binary, rest::bits>> = rest
+          <<val::size(len)-binary, rest::bits>> = rest
           {val, rest}
       end
 

--- a/lib/kayrock/record_batch.ex
+++ b/lib/kayrock/record_batch.ex
@@ -418,19 +418,16 @@ defmodule Kayrock.RecordBatch do
     end)
   end
 
-  defp serialize_record_header(%RecordHeader{key: nil, value: _val} = _header) do
-    raise RuntimeError, "Invalid null header key found in headers"
-  end
-
-  defp serialize_record_header(%RecordHeader{} = header) do
+  defp serialize_record_header(%RecordHeader{key: key, value: value})
+       when not is_nil(key) do
     encoded_value =
-      if is_nil(header.value) do
+      if is_nil(value) do
         encode_varint(-1)
       else
-        encode_varint(byte_size(header.value)) <> <<header.value::binary>>
+        encode_varint(byte_size(value)) <> <<value::binary>>
       end
 
-    encode_varint(byte_size(header.key)) <> <<header.key::binary>> <> encoded_value
+    encode_varint(byte_size(key)) <> <<key::binary>> <> encoded_value
   end
 
   defp maybe_delta(nil, _), do: nil

--- a/lib/kayrock/record_batch.ex
+++ b/lib/kayrock/record_batch.ex
@@ -7,17 +7,6 @@ defmodule Kayrock.RecordBatch do
   See https://kafka.apache.org/documentation/#recordbatch
   """
 
-  defmodule RecordHeader do
-    @moduledoc """
-    Represents a record header
-
-    Headers were added on Kafka 0.11+
-
-    See https://kafka.apache.org/documentation/#recordheader
-    """
-    defstruct( key: nil, value: nil)
-  end
-
   defmodule Record do
     @moduledoc """
     Represents a single record (message)

--- a/lib/kayrock/record_batch.ex
+++ b/lib/kayrock/record_batch.ex
@@ -392,7 +392,11 @@ defmodule Kayrock.RecordBatch do
     }
   end
 
-  defp serialize_record_headers(headers) when length(headers) == 0 do
+  defp serialize_record_headers(headers) when is_nil(headers) do
+    <<0>>
+  end
+
+  defp serialize_record_headers([] = _headers) do
     <<0>>
   end
 

--- a/test/kayrock/client/produce_test.exs
+++ b/test/kayrock/client/produce_test.exs
@@ -265,8 +265,7 @@ defmodule Kayrock.Client.ProduceTest do
       %RecordHeader{key: "type", value: "HeaderCreatedEvent"}
     ]
 
-    record_value = "record-value-here"
-    records = [%Record{headers: headers, key: "rd-k", value: record_value}]
+    records = [%Record{headers: headers, key: "rd-k", value: "record-value-here"}]
 
     record_batch = %RecordBatch{
       attributes: 0,

--- a/test/kayrock/fetch_test.exs
+++ b/test/kayrock/fetch_test.exs
@@ -793,7 +793,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 0,
                       timestamp: -1,
@@ -859,7 +859,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 0,
                       timestamp: -1,
@@ -882,7 +882,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 1,
                       timestamp: -1,
@@ -1051,7 +1051,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 83,
                       timestamp: -1,
@@ -1074,7 +1074,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 84,
                       timestamp: -1,
@@ -1097,7 +1097,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 85,
                       timestamp: -1,
@@ -1168,7 +1168,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 203,
                       timestamp: -1,
@@ -1191,7 +1191,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 204,
                       timestamp: -1,
@@ -1214,7 +1214,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 205,
                       timestamp: -1,
@@ -1284,7 +1284,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 228,
                       timestamp: -1,
@@ -1307,7 +1307,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 229,
                       timestamp: -1,
@@ -1330,7 +1330,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 230,
                       timestamp: -1,
@@ -1404,7 +1404,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 34,
                       timestamp: 1_568_164_739_263,
@@ -1427,7 +1427,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 35,
                       timestamp: 1_568_164_739_267,
@@ -1450,7 +1450,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 36,
                       timestamp: 1_568_164_739_269,
@@ -1473,7 +1473,7 @@ defmodule Kayrock.FetchTest do
                   records: [
                     %Kayrock.RecordBatch.Record{
                       attributes: 0,
-                      headers: <<0>>,
+                      headers: [],
                       key: "",
                       offset: 37,
                       timestamp: 1_568_164_739_271,

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -527,12 +527,6 @@ defmodule Kayrock.MessageSerdeTest do
   end
 
   test "serialize v2 message with headers' key nil" do
-    expected =
-      <<0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 0, 2, 123, 75, 8, 153, 0, 0, 0,
-        0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 24, 0,
-        0, 0, 6, 102, 111, 111, 6, 98, 97, 114, 0>>
-
     record_batch = %Kayrock.RecordBatch{
       attributes: 0,
       base_sequence: -1,
@@ -561,46 +555,9 @@ defmodule Kayrock.MessageSerdeTest do
       ]
     }
 
-    got = IO.iodata_to_binary(RecordBatch.serialize(record_batch))
-
-    assert got == expected, compare_binaries(got, expected)
-  end
-
-  test "deserialize v2 message with headers' key nil" do
-    data =
-      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 0, 2, 123, 75, 8, 153, 0, 0, 0, 0, 0, 0,
-        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 24, 0, 0, 0, 6,
-        102, 111, 111, 6, 98, 97, 114, 0>>
-
-    expected = [
-      %Kayrock.RecordBatch{
-        attributes: 0,
-        base_sequence: -1,
-        batch_length: 62,
-        batch_offset: 0,
-        crc: 2_068_514_969,
-        first_timestamp: -1,
-        last_offset_delta: 0,
-        max_timestamp: -1,
-        partition_leader_epoch: 0,
-        producer_epoch: -1,
-        producer_id: -1,
-        records: [
-          %Kayrock.RecordBatch.Record{
-            attributes: 0,
-            headers: [],
-            key: "foo",
-            offset: 0,
-            value: "bar"
-          }
-        ]
-      }
-    ]
-
-    got = RecordBatch.deserialize(data)
-
-    assert got == expected
+    assert_raise RuntimeError, "Invalid null header key found in headers", fn ->
+      RecordBatch.serialize(record_batch)
+    end
   end
 
   test "serialize v2 message with headers' value nil" do
@@ -626,10 +583,6 @@ defmodule Kayrock.MessageSerdeTest do
         %Kayrock.RecordBatch.Record{
           attributes: 0,
           headers: [
-            %Kayrock.RecordBatch.RecordHeader{
-              key: nil,
-              value: "623107c3-4acd-4d19-a029-9cc552ae20e7"
-            },
             %Kayrock.RecordBatch.RecordHeader{
               key: "correlation-id",
               value: nil

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -525,4 +525,82 @@ defmodule Kayrock.MessageSerdeTest do
 
     assert got == expected
   end
+
+  test "serialize v2 message with headers' key nil" do
+    expected =
+      <<0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 0, 2, 123, 75, 8, 153, 0, 0, 0,
+        0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 24, 0,
+        0, 0, 6, 102, 111, 111, 6, 98, 97, 114, 0>>
+
+    record_batch = %Kayrock.RecordBatch{
+      attributes: 0,
+      base_sequence: -1,
+      batch_length: 62,
+      batch_offset: 0,
+      crc: 2_068_514_969,
+      first_timestamp: -1,
+      last_offset_delta: 0,
+      max_timestamp: -1,
+      partition_leader_epoch: 0,
+      producer_epoch: -1,
+      producer_id: -1,
+      records: [
+        %Kayrock.RecordBatch.Record{
+          attributes: 0,
+          headers: [
+            %Kayrock.RecordBatch.RecordHeader{
+              key: nil,
+              value: "623107c3-4acd-4d19-a029-9cc552ae20e7"
+            }
+          ],
+          key: "foo",
+          offset: 0,
+          value: "bar",
+          timestamp: -1
+        }
+      ]
+    }
+
+    got = IO.iodata_to_binary(RecordBatch.serialize(record_batch))
+
+    assert got == expected, compare_binaries(got, expected)
+  end
+
+  test "deserialize v2 message with headers' key nil" do
+    data =
+      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 0, 2, 123, 75, 8, 153, 0, 0, 0, 0, 0, 0,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 24, 0, 0, 0, 6,
+        102, 111, 111, 6, 98, 97, 114, 0>>
+
+    expected = [
+      %Kayrock.RecordBatch{
+        attributes: 0,
+        base_sequence: -1,
+        batch_length: 62,
+        batch_offset: 0,
+        crc: 2_068_514_969,
+        first_timestamp: -1,
+        last_offset_delta: 0,
+        max_timestamp: -1,
+        partition_leader_epoch: 0,
+        producer_epoch: -1,
+        producer_id: -1,
+        records: [
+          %Kayrock.RecordBatch.Record{
+            attributes: 0,
+            headers: [],
+            key: "foo",
+            offset: 0,
+            value: "bar"
+          }
+        ]
+      }
+    ]
+
+    got = RecordBatch.deserialize(data)
+
+    assert got == expected
+  end
 end

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -555,7 +555,7 @@ defmodule Kayrock.MessageSerdeTest do
       ]
     }
 
-    assert_raise RuntimeError, "Invalid null header key found in headers", fn ->
+    assert_raise FunctionClauseError, fn ->
       RecordBatch.serialize(record_batch)
     end
   end

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -154,7 +154,7 @@ defmodule Kayrock.MessageSerdeTest do
       records: [
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 0,
           timestamp: -1,
@@ -162,7 +162,7 @@ defmodule Kayrock.MessageSerdeTest do
         },
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 0,
           timestamp: -1,
@@ -170,7 +170,7 @@ defmodule Kayrock.MessageSerdeTest do
         },
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 0,
           timestamp: -1,
@@ -214,7 +214,7 @@ defmodule Kayrock.MessageSerdeTest do
         records: [
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 126,
             timestamp: -1,
@@ -222,7 +222,7 @@ defmodule Kayrock.MessageSerdeTest do
           },
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 127,
             timestamp: -1,
@@ -230,7 +230,7 @@ defmodule Kayrock.MessageSerdeTest do
           },
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 128,
             timestamp: -1,
@@ -260,7 +260,7 @@ defmodule Kayrock.MessageSerdeTest do
       records: [
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 0,
           timestamp: -1,
@@ -268,7 +268,7 @@ defmodule Kayrock.MessageSerdeTest do
         },
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 1,
           timestamp: -1,
@@ -276,7 +276,7 @@ defmodule Kayrock.MessageSerdeTest do
         },
         %Kayrock.RecordBatch.Record{
           attributes: 0,
-          headers: <<0>>,
+          headers: [],
           key: nil,
           offset: 2,
           timestamp: -1,
@@ -329,7 +329,7 @@ defmodule Kayrock.MessageSerdeTest do
         records: [
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 132,
             timestamp: -1,
@@ -337,7 +337,7 @@ defmodule Kayrock.MessageSerdeTest do
           },
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 133,
             timestamp: -1,
@@ -345,7 +345,7 @@ defmodule Kayrock.MessageSerdeTest do
           },
           %Kayrock.RecordBatch.Record{
             attributes: 0,
-            headers: <<0>>,
+            headers: [],
             key: nil,
             offset: 134,
             timestamp: -1,

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -538,7 +538,6 @@ defmodule Kayrock.MessageSerdeTest do
       base_sequence: -1,
       batch_length: 62,
       batch_offset: 0,
-      crc: 2_068_514_969,
       first_timestamp: -1,
       last_offset_delta: 0,
       max_timestamp: -1,
@@ -591,6 +590,94 @@ defmodule Kayrock.MessageSerdeTest do
           %Kayrock.RecordBatch.Record{
             attributes: 0,
             headers: [],
+            key: "foo",
+            offset: 0,
+            value: "bar"
+          }
+        ]
+      }
+    ]
+
+    got = RecordBatch.deserialize(data)
+
+    assert got == expected
+  end
+
+  test "serialize v2 message with headers' value nil" do
+    expected =
+      <<0, 0, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 2, 2, 191, 115, 230, 0, 0,
+        0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 56,
+        0, 0, 0, 6, 102, 111, 111, 6, 98, 97, 114, 2, 28, 99, 111, 114, 114, 101, 108, 97, 116,
+        105, 111, 110, 45, 105, 100, 1>>
+
+    record_batch = %Kayrock.RecordBatch{
+      attributes: 0,
+      base_sequence: -1,
+      batch_length: 62,
+      batch_offset: 0,
+      first_timestamp: -1,
+      last_offset_delta: 0,
+      max_timestamp: -1,
+      partition_leader_epoch: 0,
+      producer_epoch: -1,
+      producer_id: -1,
+      records: [
+        %Kayrock.RecordBatch.Record{
+          attributes: 0,
+          headers: [
+            %Kayrock.RecordBatch.RecordHeader{
+              key: nil,
+              value: "623107c3-4acd-4d19-a029-9cc552ae20e7"
+            },
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "correlation-id",
+              value: nil
+            }
+          ],
+          key: "foo",
+          offset: 0,
+          value: "bar",
+          timestamp: -1
+        }
+      ]
+    }
+
+    got = IO.iodata_to_binary(RecordBatch.serialize(record_batch))
+
+    assert got == expected, compare_binaries(got, expected)
+  end
+
+  test "deserialize v2 message with headers' value nil" do
+    data =
+      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 2, 2, 191, 115, 230, 0, 0, 0, 0, 0, 0,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 1, 56, 0, 0, 0, 6,
+        102, 111, 111, 6, 98, 97, 114, 2, 28, 99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110,
+        45, 105, 100, 1>>
+
+    expected = [
+      %Kayrock.RecordBatch{
+        attributes: 0,
+        base_sequence: -1,
+        batch_length: 78,
+        batch_offset: 0,
+        crc: 46_101_478,
+        first_timestamp: -1,
+        last_offset_delta: 0,
+        max_timestamp: -1,
+        partition_leader_epoch: 0,
+        producer_epoch: -1,
+        producer_id: -1,
+        records: [
+          %Kayrock.RecordBatch.Record{
+            attributes: 0,
+            headers: [
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "correlation-id",
+                value: nil
+              }
+            ],
             key: "foo",
             offset: 0,
             value: "bar"

--- a/test/kayrock/message_serde_test.exs
+++ b/test/kayrock/message_serde_test.exs
@@ -358,4 +358,171 @@ defmodule Kayrock.MessageSerdeTest do
     got = RecordBatch.deserialize(data)
     assert got == expect
   end
+
+  test "serialize v2 message with headers" do
+    expected =
+      <<0, 0, 0, 208, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 0, 0, 0, 0, 2, 59, 139, 206, 9, 0, 0,
+        0, 0, 0, 2, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 3, 96,
+        0, 0, 0, 6, 98, 97, 122, 6, 102, 111, 111, 4, 4, 104, 97, 28, 104, 101, 97, 100, 101, 114,
+        95, 97, 95, 118, 97, 108, 117, 101, 4, 104, 98, 28, 104, 101, 97, 100, 101, 114, 95, 98,
+        95, 118, 97, 108, 117, 101, 96, 0, 0, 2, 6, 102, 111, 111, 6, 98, 97, 114, 4, 4, 104, 97,
+        28, 104, 101, 97, 100, 101, 114, 95, 97, 95, 118, 97, 108, 117, 101, 4, 104, 98, 28, 104,
+        101, 97, 100, 101, 114, 95, 98, 95, 118, 97, 108, 117, 101, 96, 0, 0, 4, 6, 98, 97, 114,
+        6, 98, 97, 122, 4, 4, 104, 97, 28, 104, 101, 97, 100, 101, 114, 95, 97, 95, 118, 97, 108,
+        117, 101, 4, 104, 98, 28, 104, 101, 97, 100, 101, 114, 95, 98, 95, 118, 97, 108, 117,
+        101>>
+
+    record_batch = %Kayrock.RecordBatch{
+      attributes: 0,
+      base_sequence: -1,
+      batch_length: 196,
+      batch_offset: 0,
+      crc: 999_017_993,
+      first_timestamp: -1,
+      last_offset_delta: 2,
+      max_timestamp: -1,
+      partition_leader_epoch: 0,
+      producer_epoch: -1,
+      producer_id: -1,
+      records: [
+        %Kayrock.RecordBatch.Record{
+          attributes: 0,
+          headers: [
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "ha",
+              value: "header_a_value"
+            },
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "hb",
+              value: "header_b_value"
+            }
+          ],
+          key: "baz",
+          offset: 0,
+          value: "foo"
+        },
+        %Kayrock.RecordBatch.Record{
+          attributes: 0,
+          headers: [
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "ha",
+              value: "header_a_value"
+            },
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "hb",
+              value: "header_b_value"
+            }
+          ],
+          key: "foo",
+          offset: 1,
+          value: "bar"
+        },
+        %Kayrock.RecordBatch.Record{
+          attributes: 0,
+          headers: [
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "ha",
+              value: "header_a_value"
+            },
+            %Kayrock.RecordBatch.RecordHeader{
+              key: "hb",
+              value: "header_b_value"
+            }
+          ],
+          key: "bar",
+          offset: 2,
+          value: "baz"
+        }
+      ]
+    }
+
+    got = IO.iodata_to_binary(RecordBatch.serialize(record_batch))
+
+    assert got == expected, compare_binaries(got, expected)
+  end
+
+  test "deserialize v2 message with headers" do
+    data =
+      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 196, 0, 0, 0, 0, 2, 59, 139, 206, 9, 0, 0, 0, 0, 0, 2,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+        255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 3, 96, 0, 0, 0, 6,
+        98, 97, 122, 6, 102, 111, 111, 4, 4, 104, 97, 28, 104, 101, 97, 100, 101, 114, 95, 97, 95,
+        118, 97, 108, 117, 101, 4, 104, 98, 28, 104, 101, 97, 100, 101, 114, 95, 98, 95, 118, 97,
+        108, 117, 101, 96, 0, 0, 2, 6, 102, 111, 111, 6, 98, 97, 114, 4, 4, 104, 97, 28, 104, 101,
+        97, 100, 101, 114, 95, 97, 95, 118, 97, 108, 117, 101, 4, 104, 98, 28, 104, 101, 97, 100,
+        101, 114, 95, 98, 95, 118, 97, 108, 117, 101, 96, 0, 0, 4, 6, 98, 97, 114, 6, 98, 97, 122,
+        4, 4, 104, 97, 28, 104, 101, 97, 100, 101, 114, 95, 97, 95, 118, 97, 108, 117, 101, 4,
+        104, 98, 28, 104, 101, 97, 100, 101, 114, 95, 98, 95, 118, 97, 108, 117, 101>>
+
+    expected = [
+      %Kayrock.RecordBatch{
+        attributes: 0,
+        base_sequence: -1,
+        batch_length: 196,
+        batch_offset: 0,
+        crc: 999_017_993,
+        first_timestamp: -1,
+        last_offset_delta: 2,
+        max_timestamp: -1,
+        partition_leader_epoch: 0,
+        producer_epoch: -1,
+        producer_id: -1,
+        records: [
+          %Kayrock.RecordBatch.Record{
+            attributes: 0,
+            headers: [
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "ha",
+                value: "header_a_value"
+              },
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "hb",
+                value: "header_b_value"
+              }
+            ],
+            key: "baz",
+            offset: 0,
+            value: "foo"
+          },
+          %Kayrock.RecordBatch.Record{
+            attributes: 0,
+            headers: [
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "ha",
+                value: "header_a_value"
+              },
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "hb",
+                value: "header_b_value"
+              }
+            ],
+            key: "foo",
+            offset: 1,
+            value: "bar"
+          },
+          %Kayrock.RecordBatch.Record{
+            attributes: 0,
+            headers: [
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "ha",
+                value: "header_a_value"
+              },
+              %Kayrock.RecordBatch.RecordHeader{
+                key: "hb",
+                value: "header_b_value"
+              }
+            ],
+            key: "bar",
+            offset: 2,
+            value: "baz"
+          }
+        ]
+      }
+    ]
+
+    got = RecordBatch.deserialize(data)
+
+    assert got == expected
+  end
 end


### PR DESCRIPTION
This PR (de)serialize headers on `Record`, according with Kafka
protocol the Record's headers are lists supporting multiple entries of
key/value structure.

The headers before defined as `<<0>>` were replaced by `[]` which
matches with protocol definition.

- [x]  add record's headers
- [x] deal with null header's keys and values
- [x]  add tests for message (de)serialization
- [x] fix credo and dialyzer findinds