### PR TITLE
Set minimum elixir version to 1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Kayrock.MixProject do
     [
       app: :kayrock,
       version: "0.1.13",
-      elixir: "~> 1.1",
+      elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [coveralls: :test],


### PR DESCRIPTION
the `__STACKTRACE__` macro used in this lib was added in elixir 1.7. This is also the oldest version supported in the integration tests.

Bump the elixir version to make it clear that this library will not function correctly on older elixir versions.